### PR TITLE
Optional java kotlin dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,9 @@ intellijPlatform {
 dependencies {
     implementation("org.antlr:antlr4:4.13.1")
     testImplementation("junit:junit:4.13.2")
-    implementation("co.elastic.clients:elasticsearch-java:9.3.4")
+    implementation("co.elastic.clients:elasticsearch-java:9.3.4") {
+        exclude(group = "org.slf4j")
+    }
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation(project(":antlr"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,7 @@ intellijPlatform {
 dependencies {
     implementation("org.antlr:antlr4:4.13.1")
     testImplementation("junit:junit:4.13.2")
-    implementation("co.elastic.clients:elasticsearch-java:9.3.1")
+    implementation("co.elastic.clients:elasticsearch-java:9.3.4")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation(project(":antlr"))
 }

--- a/src/main/java/co/elastic/plugin/CommonUtils.java
+++ b/src/main/java/co/elastic/plugin/CommonUtils.java
@@ -25,18 +25,14 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
-import com.intellij.psi.PsiLiteralExpression;
 import com.intellij.psi.PsiPlainText;
 import com.intellij.psi.TokenType;
-import com.intellij.psi.impl.source.tree.java.PsiJavaTokenImpl;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
-import static com.intellij.psi.JavaTokenType.TEXT_BLOCK_LITERAL;
 
 public class CommonUtils {
 
@@ -240,14 +236,11 @@ public class CommonUtils {
             return false;
         }
 
-        // it's a literal expression
-        // PsiLiteralExpression for java
-        if (element instanceof PsiLiteralExpression) {
-            // it's a text block (triple quote)
-            if (((PsiJavaTokenImpl) element.getFirstChild()).getElementType().equals(TEXT_BLOCK_LITERAL)) {
-
-                return checkEsqlCommentAbove(element);
-            }
+        // it's a literal expression (Java text block with triple quotes)
+        PsiElement firstChild = element.getFirstChild();
+        if (firstChild != null && firstChild.getNode() != null
+            && "TEXT_BLOCK_LITERAL".equals(firstChild.getNode().getElementType().toString())) {
+            return checkEsqlCommentAbove(element);
         }
 
         // STRING_TEMPLATE to match kotlin triple quote

--- a/src/main/java/co/elastic/plugin/annotator/EsqlAnnotator.java
+++ b/src/main/java/co/elastic/plugin/annotator/EsqlAnnotator.java
@@ -31,11 +31,7 @@ import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
-import com.intellij.psi.PsiLiteralExpression;
 import com.intellij.psi.PsiPlainText;
-import com.intellij.psi.TokenType;
-import com.intellij.psi.impl.source.tree.java.PsiJavaTokenImpl;
-import com.intellij.psi.tree.IElementType;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.jetbrains.annotations.NotNull;
@@ -52,11 +48,8 @@ import static co.elastic.plugin.CommonUtils.ESQL_SEPARATORS;
 import static co.elastic.plugin.CommonUtils.FUNCTIONS;
 import static co.elastic.plugin.CommonUtils.PROCESSING_COMMANDS;
 import static co.elastic.plugin.CommonUtils.SOURCE_COMMANDS;
-import static co.elastic.plugin.CommonUtils.checkEsqlCommentAbove;
 import static co.elastic.plugin.CommonUtils.findEsqlBlocksInPlainText;
 import static co.elastic.plugin.CommonUtils.isEsqlTextBlock;
-import static com.intellij.psi.JavaTokenType.TEXT_BLOCK_LITERAL;
-
 /**
  * Checks the query syntax and underlines errors.
  */

--- a/src/main/java/co/elastic/plugin/autocomplete/EsqlCompletionConfidence.java
+++ b/src/main/java/co/elastic/plugin/autocomplete/EsqlCompletionConfidence.java
@@ -28,8 +28,6 @@ import com.intellij.psi.PsiPlainText;
 import com.intellij.util.ThreeState;
 import org.jetbrains.annotations.NotNull;
 
-import static com.intellij.psi.JavaTokenType.TEXT_BLOCK_LITERAL;
-
 public class EsqlCompletionConfidence extends CompletionConfidence {
 
     @Override
@@ -39,8 +37,9 @@ public class EsqlCompletionConfidence extends CompletionConfidence {
             return ThreeState.UNSURE;
         }
 
-        boolean isStringLiteral = node.getElementType().equals(TEXT_BLOCK_LITERAL)
-            || node.getElementType().toString().equals("REGULAR_STRING_PART")
+        String elementType = node.getElementType().toString();
+        boolean isStringLiteral = "TEXT_BLOCK_LITERAL".equals(elementType)
+            || "REGULAR_STRING_PART".equals(elementType)
             || contextElement instanceof PsiPlainText;
 
         // for kotlin, navigate up to the STRING_TEMPLATE element

--- a/src/main/java/co/elastic/plugin/autocomplete/StringLiteralPattern.java
+++ b/src/main/java/co/elastic/plugin/autocomplete/StringLiteralPattern.java
@@ -25,8 +25,6 @@ import com.intellij.psi.PsiPlainText;
 import com.intellij.util.ProcessingContext;
 import org.jetbrains.annotations.NotNull;
 
-import static com.intellij.psi.JavaTokenType.TEXT_BLOCK_LITERAL;
-
 public class StringLiteralPattern extends PatternCondition<PsiElement> {
 
     public StringLiteralPattern() {
@@ -38,13 +36,15 @@ public class StringLiteralPattern extends PatternCondition<PsiElement> {
 
         ASTNode node = psi.getNode();
         if (node == null) {
-            System.out.println("No node found");
             return false;
         }
 
         // checking java text block literal, kotlin string literal and plain text psi
         // (kotlin psi makes no difference between normal string and triple quotes text block)
-        return node.getElementType().equals(TEXT_BLOCK_LITERAL) || node.getElementType().toString().equals("REGULAR_STRING_PART") || psi instanceof PsiPlainText;
+        String elementType = node.getElementType().toString();
+        return "TEXT_BLOCK_LITERAL".equals(elementType)
+            || "REGULAR_STRING_PART".equals(elementType)
+            || psi instanceof PsiPlainText;
     }
 }
 

--- a/src/main/java/co/elastic/plugin/documentation/EsqlDocumentationProvider.java
+++ b/src/main/java/co/elastic/plugin/documentation/EsqlDocumentationProvider.java
@@ -34,7 +34,6 @@ import java.util.List;
 import static co.elastic.plugin.CommonUtils.ESQL_SEPARATORS;
 import static co.elastic.plugin.CommonUtils.checkEsqlCommentAbove;
 import static co.elastic.plugin.CommonUtils.isKotlinString;
-import static com.intellij.psi.JavaTokenType.TEXT_BLOCK_LITERAL;
 
 @SuppressWarnings("UnstableApiUsage")
 public class EsqlDocumentationProvider implements DocumentationTargetProvider {
@@ -46,7 +45,7 @@ public class EsqlDocumentationProvider implements DocumentationTargetProvider {
         if (elementAtOffset.getLanguage().is(Language.findLanguageByID("kotlin"))) {
             elementAtOffset = elementAtOffset.getParent().getParent();
         }
-        if (elementAtOffset == null || !(elementAtOffset.getNode().getElementType().equals(TEXT_BLOCK_LITERAL)
+        if (elementAtOffset == null || !("TEXT_BLOCK_LITERAL".equals(elementAtOffset.getNode().getElementType().toString())
                                          || isKotlinString(elementAtOffset)
                                          || elementAtOffset instanceof PsiPlainText)
             || !checkEsqlCommentAbove(elementAtOffset, i)) {

--- a/src/main/resources/META-INF/esql-withJava.xml
+++ b/src/main/resources/META-INF/esql-withJava.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+  <extensions defaultExtensionNs="com.intellij">
+    <annotator language="JAVA" implementationClass="co.elastic.plugin.annotator.EsqlAnnotator"/>
+  </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/esql-withKotlin.xml
+++ b/src/main/resources/META-INF/esql-withKotlin.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+  <extensions defaultExtensionNs="com.intellij">
+    <annotator language="kotlin" implementationClass="co.elastic.plugin.annotator.EsqlAnnotator"/>
+  </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,7 +37,8 @@
        Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>
-  <depends>com.intellij.java</depends>
+  <depends optional="true" config-file="esql-withJava.xml">com.intellij.java</depends>
+  <depends optional="true" config-file="esql-withKotlin.xml">org.jetbrains.kotlin</depends>
 
   <!-- Extension points defined by the plugin.
        Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
@@ -54,8 +55,6 @@
       language="any"
       order="first"
     />
-    <annotator language="JAVA" implementationClass="co.elastic.plugin.annotator.EsqlAnnotator"/>
-    <annotator language="kotlin" implementationClass="co.elastic.plugin.annotator.EsqlAnnotator"/>
     <annotator language="TEXT" implementationClass="co.elastic.plugin.annotator.EsqlAnnotator"/>
 
     <platform.backend.documentation.targetProvider order="first" implementation="co.elastic.plugin.documentation.EsqlDocumentationProvider"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -40,6 +40,10 @@
   <depends optional="true" config-file="esql-withJava.xml">com.intellij.java</depends>
   <depends optional="true" config-file="esql-withKotlin.xml">org.jetbrains.kotlin</depends>
 
+  <extensions defaultExtensionNs="org.jetbrains.kotlin">
+    <supportsKotlinPluginMode supportsK2="true"/>
+  </extensions>
+
   <!-- Extension points defined by the plugin.
        Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
   <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
Fixing issue where plugin was incompatible with most Jetbrains product due to java and kotlin being necessary dependencies, by making the language dependency optional, so that IDEs that don't support java/kotlin can still use the plugin with txt files.

Fixes #30 