### PR TITLE
Making plugin compatible with es 8.x

### DIFF
--- a/src/main/java/co/elastic/plugin/CommonUtils.java
+++ b/src/main/java/co/elastic/plugin/CommonUtils.java
@@ -18,6 +18,7 @@
  */
 package co.elastic.plugin;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.intellij.lang.Language;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.project.Project;
@@ -249,5 +250,16 @@ public class CommonUtils {
         }
 
         return false;
+    }
+
+    public static ElasticsearchClient createClientInstance(String url, String apikey) {
+        return ElasticsearchClient.of(b -> b
+            .host(url)
+            .apiKey(apikey)
+            .transportOptions(t -> t
+                .setHeader("Content-Type", "application/vnd.elasticsearch+json; compatible-with=8")
+                .setHeader("Accept", "application/vnd.elasticsearch+json; compatible-with=8")
+            )
+        );
     }
 }

--- a/src/main/java/co/elastic/plugin/connection/EsqlPluginQueryManager.java
+++ b/src/main/java/co/elastic/plugin/connection/EsqlPluginQueryManager.java
@@ -21,6 +21,7 @@ package co.elastic.plugin.connection;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import co.elastic.plugin.CommonUtils;
 import co.elastic.plugin.settings.EsqlConnection;
 import co.elastic.plugin.settings.EsqlPluginSettings;
 import com.intellij.openapi.application.ApplicationManager;
@@ -43,10 +44,12 @@ public final class EsqlPluginQueryManager implements EsqlSchemaProvider {
         final ConcurrentHashMap<String, List<String>> indicesAndFields = new ConcurrentHashMap<>();
     }
 
-    public record CachedResult(String query, EsqlQueryResult result, long elapsedMs) {}
+    public record CachedResult(String query, EsqlQueryResult result, long elapsedMs) {
+    }
 
     private final ScheduledExecutorService scheduler = AppExecutorUtil.getAppScheduledExecutorService();
-    private final EsqlPluginSettings settings = ApplicationManager.getApplication().getService(EsqlPluginSettings.class);
+    private final EsqlPluginSettings settings =
+        ApplicationManager.getApplication().getService(EsqlPluginSettings.class);
     private final ConcurrentHashMap<String, ConnectionState> activeConnections = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, List<CachedResult>> cachedResults = new ConcurrentHashMap<>();
 
@@ -109,10 +112,7 @@ public final class EsqlPluginQueryManager implements EsqlSchemaProvider {
         if (conn == null || conn.serverUrl.isEmpty() || conn.apiKey.isEmpty()) {
             return "URL and API key are required";
         }
-        try (ElasticsearchClient client = ElasticsearchClient.of(b -> b
-            .host(conn.serverUrl)
-            .apiKey(conn.apiKey)
-        )) {
+        try (ElasticsearchClient client = CommonUtils.createClientInstance(conn.serverUrl, conn.apiKey)) {
             client.ping();
             return null;
         } catch (ElasticsearchException e) {
@@ -155,10 +155,8 @@ public final class EsqlPluginQueryManager implements EsqlSchemaProvider {
 
     private void startQueryThreadPool(String connectionName, EsqlConnection conn, ConnectionState state) {
         state.task = scheduler.scheduleWithFixedDelay(() -> {
-            try (ElasticsearchClient client = ElasticsearchClient.of(b -> b
-                .host(conn.serverUrl)
-                .apiKey(conn.apiKey)
-            )) {
+            try (ElasticsearchClient client = CommonUtils.createClientInstance(conn.serverUrl,conn.apiKey)) {
+
                 List<String> indices = client.indices().get(g -> g.index("*"))
                     .indices().keySet().stream()
                     .filter(x -> !x.startsWith(".internal") && !x.startsWith(".ds"))

--- a/src/main/java/co/elastic/plugin/connection/EsqlQueryExecutor.java
+++ b/src/main/java/co/elastic/plugin/connection/EsqlQueryExecutor.java
@@ -23,6 +23,7 @@ import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch.esql.EsqlFormat;
 import co.elastic.clients.elasticsearch.esql.QueryRequest;
 import co.elastic.clients.transport.endpoints.BinaryResponse;
+import co.elastic.plugin.CommonUtils;
 import co.elastic.plugin.settings.EsqlPluginSettings;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -58,10 +59,7 @@ public class EsqlQueryExecutor {
                                          "Elasticsearch panel.");
         }
 
-        try (ElasticsearchClient client = ElasticsearchClient.of(b -> b
-            .host(serverUrl)
-            .apiKey(apiKey)
-        )) {
+        try (ElasticsearchClient client = CommonUtils.createClientInstance(serverUrl,apiKey)) {
 
             BinaryResponse response = client.esql()
                 .query(QueryRequest.of(q -> q.query(query).format(EsqlFormat.Json)));

--- a/src/main/java/co/elastic/plugin/settings/EsqlConnectionDialog.java
+++ b/src/main/java/co/elastic/plugin/settings/EsqlConnectionDialog.java
@@ -20,6 +20,7 @@ package co.elastic.plugin.settings;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.plugin.CommonUtils;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.ValidationInfo;
@@ -133,10 +134,7 @@ public class EsqlConnectionDialog extends DialogWrapper {
         SwingWorker<String, Void> worker = new SwingWorker<>() {
             @Override
             protected String doInBackground() {
-                try (ElasticsearchClient client = ElasticsearchClient.of(b -> b
-                    .host(serverUrl)
-                    .apiKey(apiKey)
-                )) {
+                try (ElasticsearchClient client = CommonUtils.createClientInstance(serverUrl,apiKey)) {
                     client.ping();
                     return null;
                 } catch (ElasticsearchException e) {


### PR DESCRIPTION
Fixes #33.
The plugin uses the [elasticsearch-java](https://github.com/elastic/elasticsearch-java) client version 9.x to connect to es instances, which returns error when trying to connect with 8.x instances, for API compatibility reasons. Since, as of now, there's no specific 9.x API usage in the plugin, adding a bypass to the client check so that the plugin can correctly connect to 8.x instances. 